### PR TITLE
Update spritesmith

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "spritesmith": "~1.0.3",
+    "spritesmith": "~1.3.0",
     "lodash": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update spritesmith to latest, old version exception with errors (with last version or with `params.algorithm: top-down` it's ok):

```
Fatal error: Cannot read property 'x' of null
TypeError: Cannot read property 'x' of null
    at /Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/layout/lib/algorithms/binary-tree.algorithm.js:33:17
    at Array.forEach (native)
    at Object.exports.placeItems (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/layout/lib/algorithms/binary-tree.algorithm.js:31:9)
    at Object.PackingSmith.processItems (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/layout/lib/smiths/packing.smith.js:83:28)
    at Object.PackingSmith.exportItems (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/layout/lib/smiths/packing.smith.js:93:10)
    at Object.PackingSmith.export (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/layout/lib/smiths/packing.smith.js:109:22)
    at smithOutputCoordinates (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/src/smith.js:91:34)
    at fn (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/async/lib/async.js:582:34)
    at Immediate._onImmediate (/Users/anton/mrg/health2/node_modules/grunt-tamia-sprite/node_modules/spritesmith/node_modules/async/lib/async.js:498:34)
    at processImmediate [as _immediateCallback] (timers.js:358:17)
```
